### PR TITLE
add node-module splitting

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -93,6 +93,17 @@ module.exports = {
         splitChunks: {
             chunks: 'all',
             cacheGroups: {
+                vendor: {
+                    test: /[\\/]node_modules[\\/]/,
+                    name(module) {
+                      // get the name. E.g. node_modules/packageName/not/this/part.js
+                      // or node_modules/packageName
+                      const packageName = module.context.match(/[\\/]node_modules[\\/](.*?)([\\/]|$)/)[1];
+          
+                      // npm package names are URL-safe, but some servers don't like @ symbols
+                      return `npm.${packageName.replace('@', '')}`;
+                    },
+                },
                 // Create a commons chunk, which includes all code shared between entry points.
                 commons: {
                     name: 'commons',


### PR DESCRIPTION
I have added the splitting of node modules into separate files as per their package names. Done as suggested by the medium article. Still have a few queries regarding the `maxInitialRequests`, `runtimeChunk`, `minSize` and `commons` parameters. So, have left that out.