### PR TITLE
Add github action to build docker container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,101 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+
+    tags:
+      - '*'
+
+  pull_request:
+
+env:
+  MAIN_REPO: Oceans-1876/challenger-portal
+
+jobs:
+
+# ----------------------------------------------------------------------
+  # NODE BUILD
+  # ----------------------------------------------------------------------
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node:
+          - "12"
+          - "14"
+          - "16"
+    steps:
+    # checkout source code
+    - uses: actions/checkout@v2
+
+    # setup node
+    - uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node }}
+
+    # install dependencies
+    - name: install dependencies
+      run: npm install
+
+    # compile UI
+    - name: build
+      run: npm run build
+
+    # ----------------------------------------------------------------------
+  # DOCKER BUILD
+  # ----------------------------------------------------------------------
+  docker:
+    runs-on: ubuntu-latest
+
+    steps:
+    # checkout source code
+    - uses: actions/checkout@v2
+
+   # calculate some variables that are used later
+    - name: version information
+      run: |
+        if [ "${{ github.event.release.target_commitish }}" != "" ]; then
+          BRANCH="${{ github.event.release.target_commitish }}"
+        elif [[ $GITHUB_REF =~ pull ]]; then
+          BRANCH="$(echo $GITHUB_REF | sed 's#refs/pull/\([0-9]*\)/merge#PR-\1#')"
+        else
+          BRANCH=${GITHUB_REF##*/}
+        fi
+        echo "GITHUB_BRANCH=${BRANCH}" >> $GITHUB_ENV
+        if [ "$BRANCH" == "main" ]; then
+          version=$(cat package.json | grep \"version\" | head -1 | awk -F= "{ print $2 }" | sed 's/[version:,",]//g' | tr -d '[[:space:]]')
+          tags="latest"
+          oldversion=""
+          while [ "${oldversion}" != "${version}" ]; do
+            oldversion="${version}"
+            tags="${tags},${version}"
+            version=${version%.*}
+          done
+          echo "VERSION=${version}" >> $GITHUB_ENV
+          echo "TAGS=${tags}" >> $GITHUB_ENV
+        elif [ "$BRANCH" == "develop" ]; then
+          echo "VERSION=develop" >> $GITHUB_ENV
+          echo "TAGS=develop" >> $GITHUB_ENV
+        else
+          echo "VERSION=testing" >> $GITHUB_ENV
+          echo "TAGS=${BRANCH}" >> $GITHUB_ENV
+        fi
+    # build image
+    - name: Build image
+      uses: elgohr/Publish-Docker-Github-Action@3.04
+      env:
+        BRANCH: ${{ env.GITHUB_BRANCH }}
+        VERSION: ${{ env.VERSION }}
+        BUILDNUMBER: ${{ github.run_number }}
+        GITSHA1: ${{ github.sha }}
+      with:
+        name: oceans-1876/frontend
+        tags: "${{ env.TAGS }}"
+        buildargs: BRANCH,VERSION,BUILDNUMBER,GITSHA1
+        no_push: true
+


### PR DESCRIPTION
A few things we can address in this PR if we want to:

1. We can add a MAPBOX_TOKEN secret so the docker image builds with a token for rendering the map
2. We could push these images to a registry (currently this just builds it). hub.ncsa is an option if we want to push somewhere for the short term.