### PR TITLE
Add text tab for selected station in the sidebar

### DIFF
--- a/src/components/Explore/Sidebar.tsx
+++ b/src/components/Explore/Sidebar.tsx
@@ -8,6 +8,7 @@ import Intro from '../Intro';
 import TabsGroup from '../TabsGroup';
 import StationDetails from '../Station/Details';
 import StationSpecies from '../Station/Species';
+import StationText from '../Station/Text';
 
 const Sidebar = () => {
     const dataActionDispatcher = React.useContext(DataActionDispatcherContext);
@@ -22,7 +23,8 @@ const Sidebar = () => {
                         initialPanel="Station"
                         panels={[
                             { Panel: () => <StationDetails station={selectedStation} />, label: 'Station' },
-                            { Panel: () => <StationSpecies station={selectedStation} />, label: 'Species' }
+                            { Panel: () => <StationSpecies station={selectedStation} />, label: 'Species' },
+                            { Panel: () => <StationText station={selectedStation} />, label: 'Text' }
                         ]}
                     />
                     <Box sx={{ alignSelf: 'center' }}>

--- a/src/components/Home/index.tsx
+++ b/src/components/Home/index.tsx
@@ -69,21 +69,41 @@ const Home = (): JSX.Element => (
         <Card sx={{ mb: 2 }}>
             <CardMedia component="img" image={mapImage} alt="World Map" />
         </Card>
-        <Typography variant="body1">
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam tincidunt risus quis vestibulum congue.
-            Phasellus auctor a ipsum at sollicitudin. Vivamus cursus fringilla dolor ut pharetra. Aenean Aenean viverra
-            rhoncus purus, id accumsan ipsum consectetur nec. In eget commodo eros, et accumsan accumsan tortor.
-            Vestibulum sit amet dolor vehicula, luctus mauris ac, semper velit. Maecenas convallis et elit non congue.
-            Vivamus vel ligula id nunc cursus tincidunt. Donec a efficitur ante, ante, vitae dictum sapien. Donec
-            dignissim neque id eros rhoncus vulputate. Duis id risus et orci orci sagittis molestie. Morbi eget
-            tincidunt purus.
-        </Typography>
-        <Typography variant="body1">
-            Etiam mattis nulla quis ex maximus accumsan. Vivamus pretium tempus dui, sed viverra quam ullamcorper in.
-            Nullam pharetra ullamcorper lectus sed laoreet. Fusce tempor at lorem ac porttitor. porttitor. Morbi
-            pellentesque venenatis quam, et tincidunt mi egestas at. Duis suscipit rhoncus leo leo suscipit efficitur.
-            Nulla et mollis sapien.
-        </Typography>
+        <Box sx={{ width: '75%' }}>
+            <Typography variant="subtitle1">
+                Explore the world&#39;s oceans with <i>HMS Challenger</i> on her monumental four-year odyssey (1872-76)!
+                Search for marine species, and compare the ocean temperatures and chemistry of the pre-industrial age
+                150 years ago with the warming seas of today. Click on the <i>Oceans 1876</i> map, and zoom in on any of
+                the 364 stations from Hawaii to Antarctica for information on <i>Challenger&#39;s</i> amazing
+                discoveries…
+            </Typography>
+            <Typography sx={{ textAlign: 'center', p: 3 }} variant="h4">
+                Background
+            </Typography>
+            <Typography variant="subtitle1">
+                In December 1872, <i>HMS Challenger</i>, a small British warship converted into the world&#39;s first
+                floating laboratory left Portsmouth on a four-year voyage across the globe. Its pathbreaking mission was
+                to chart the ocean floor, measure ocean temperatures and chemistry, and collect marine specimens from
+                worldwide coastal shores, reefs, and the unexplored deep sea.
+            </Typography>
+            <Typography variant="subtitle1">
+                By the voyage&#39;s end, <i>Challenger</i> had wildly exceeded even these ambitious expectations.
+                Sailing nearly 70,000 miles, and recording data at over 360 individual stations, <i>Challenger</i>{' '}
+                identified the world&#39;s major ocean basins and currents as well as 4,700 new species of marine
+                creatures and plants.
+            </Typography>
+            <Typography variant="subtitle1">
+                The thousands of bottled specimens, deposited largely in the Natural History Museum in London, plus
+                fifty published volumes of <i>Challenger</i> data, inaugurated the modern fields of oceanography and
+                marine biology.
+            </Typography>
+            <Typography variant="subtitle1">
+                Here, for the first time, <i>Challenger&#39;s</i> vast trove of groundbreaking data is at everyone&#39;s
+                fingertips, with vital lessons for today&#39;s world. How have our oceans, and their creatures, been
+                transformed over the last 150 years? And how can we protect the wonderful diversity of marine life into
+                an uncertain future?
+            </Typography>
+        </Box>
     </Box>
 );
 

--- a/src/components/Station/Text.tsx
+++ b/src/components/Station/Text.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import Accordion from '@mui/material/Accordion';
+import AccordionSummary from '@mui/material/AccordionSummary';
+import AccordionDetails from '@mui/material/AccordionDetails';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Dialog from '@mui/material/Dialog';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import Icon from '@mui/material/Icon';
+import IconButton from '@mui/material/IconButton';
+import Link from '@mui/material/Link';
+import List from '@mui/material/List';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemText from '@mui/material/ListItemText';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+
+import { useStationDetails } from '../../utils/hooks';
+
+interface Props {
+    station: StationSummary;
+}
+
+const Text = ({ station }: Props) => {
+    const stationDetails = useStationDetails(station.name);
+    const [selectedHathiTrustUrl, setSelectedHathiTrustUrl] = React.useState<string | null>(null);
+
+    return stationDetails ? (
+        <Stack spacing={2}>
+            <Alert severity="warning">
+                <Typography variant="subtitle2">
+                    This text is from the scanned reports of <i>HMS Challenger</i> available at&nbsp;
+                    <Link
+                        href="https://catalog.hathitrust.org/Record/001473257"
+                        target="_blank"
+                        rel="noreferrer,nofollow"
+                    >
+                        HathiTrust
+                    </Link>
+                    .&nbsp;The text format and structure is as it appears in the OCRed document.
+                </Typography>
+            </Alert>
+            <Accordion square disableGutters>
+                <AccordionSummary expandIcon={<Icon>expand_more</Icon>}>
+                    <Typography>See in HathiTrust</Typography>
+                </AccordionSummary>
+                <AccordionDetails>
+                    <List dense disablePadding>
+                        {stationDetails.hathitrust_urls.map((url, idx) => (
+                            <ListItemButton
+                                key={url}
+                                dense
+                                disableGutters
+                                onClick={() => setSelectedHathiTrustUrl(url)}
+                            >
+                                <ListItemText primary={`Part ${idx + 1}`} />
+                            </ListItemButton>
+                        ))}
+                    </List>
+                    {selectedHathiTrustUrl ? (
+                        <Dialog
+                            PaperProps={{
+                                sx: { alignItems: 'center', height: '100%' }
+                            }}
+                            fullWidth
+                            maxWidth={false}
+                            open
+                            onClose={() => setSelectedHathiTrustUrl(null)}
+                        >
+                            <DialogTitle>
+                                Station {stationDetails.name} - HathiTrust&nbsp;
+                                <Link href={selectedHathiTrustUrl} target="_blank" rel="noreferrer,nofollow">
+                                    <IconButton>
+                                        <Icon>launch</Icon>
+                                    </IconButton>
+                                </Link>
+                                <IconButton
+                                    sx={{
+                                        position: 'absolute',
+                                        right: 8,
+                                        top: 8
+                                    }}
+                                    onClick={() => setSelectedHathiTrustUrl(null)}
+                                >
+                                    <Icon>close</Icon>
+                                </IconButton>
+                            </DialogTitle>
+                            <DialogContent sx={{ width: '100%', display: 'flex', justifyContent: 'center' }}>
+                                <Box
+                                    sx={{ width: 'calc(100% - 64px)', height: 'calc(100% - 64px)' }}
+                                    component="iframe"
+                                    src={`${selectedHathiTrustUrl}%3Bui=embed`}
+                                    title={`Station ${stationDetails.name} - HathiTrust`}
+                                />
+                            </DialogContent>
+                        </Dialog>
+                    ) : null}
+                </AccordionDetails>
+            </Accordion>
+            <Typography sx={{ whiteSpace: 'break-spaces' }} variant="body1" component="pre">
+                {stationDetails.text}
+            </Typography>
+        </Stack>
+    ) : null;
+};
+
+export default Text;

--- a/src/components/TabsGroup.tsx
+++ b/src/components/TabsGroup.tsx
@@ -36,6 +36,7 @@ const TabsGroup = ({ sx, panels, initialPanel }: Props) => {
         <Box
             sx={{
                 overflowY: 'auto',
+                zIndex: 1,
                 ...sx
             }}
         >

--- a/src/types/data.d.ts
+++ b/src/types/data.d.ts
@@ -22,6 +22,7 @@ interface StationDetails extends StationSummary {
         [depth: string]: ?number;
     };
     text: string;
+    hathitrust_urls: string[];
     species: SpeciesSummary[];
 }
 


### PR DESCRIPTION
The new tab contains the raw text from OCRed texts and an embedded iframe with HathiTrust documents.

Depends on https://github.com/Oceans-1876/challenger-api/pull/43.

Resolves #24