### PR TITLE
add manual ci workflow option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  workflow_dispatch:
+  
   push:
     branches:
       - main


### PR DESCRIPTION
I wanted to run a manual build but saw that the CI file doesn't support `workflow_dispatch` option so, I thought of adding this so that I could manually build images. If this was intentionally left out then we can simply close this PR and delete the branch.